### PR TITLE
Update contrib.json

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -193,6 +193,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-pig",
+            "previous_names": "PigLinter",
+            "details": "https://github.com/knightwu/SublimeLinter-contrib-pig",
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "details": "https://github.com/knightwu/SublimeLinter-contrib-pig/tree/master"
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-puppet",
             "details": "https://github.com/stopdropandrew/SublimeLinter-puppet",
             "labels": ["linting", "SublimeLinter", "puppet"],


### PR DESCRIPTION
I create a pig linter. 
It makes use of the pig executable file to parse the pig code and gets the error line number from the output.
Since the pig compiler can not get all the errors in one time, so I use some tricks likes providing artificial parameters , replacing macro with load statement and so on to get the real error.