### PR TITLE
Use 3.0.0 not 3.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,5 +1,5 @@
 {
-	"schema_version": "3.0",
+	"schema_version": "3.0.0",
 	"packages": [],
 	"includes": [
 		"./org.json",


### PR DESCRIPTION
I noticed SublimeLinter is [showing as "missing" in package control](https://packagecontrol.io/packages/SublimeLinter), error message says "3.0" is not a valid version, "3.0.0" is?