### PR TITLE
Update contrib.json to use new glua linter url.

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -147,7 +147,7 @@
         },
         {
             "name": "SublimeLinter-contrib-glua",
-            "details": "https://github.com/gmodcoders/SublimeLinter-contrib-glua",
+            "details": "https://github.com/glua/SublimeLinter-contrib-glua",
             "labels": ["linting", "SublimeLinter", "glua", "gmod", "lua"],
             "releases": [
                 {


### PR DESCRIPTION
Recently the 'gmodcoders' GitHub organization has changed its name to 'glua'. This fixes the glua linter's url.