### PR TITLE
Add SublimeLinter-contrib-htmlhint: new html linter using htmlhint

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -234,6 +234,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-htmlhint",
+            "details": "https://github.com/mmaday/SublimeLinter-contrib-htmlhint",
+            "labels": ["linting", "SublimeLinter", "html"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-iverilog",
             "details": "https://github.com/jfcherng/SublimeLinter-contrib-iverilog",
             "labels": ["linting", "SublimeLinter", "verilog"],


### PR DESCRIPTION
Add new html linter using htmlhint: https://github.com/mmaday/SublimeLinter-contrib-htmlhint.  Refer to https://github.com/SublimeLinter/SublimeLinter3/issues/245#issuecomment-94094948 for code review and comments.