### PR TITLE
add SublimeLinter-contrib-makensis

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -510,6 +510,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-makensis",
+            "details": "https://github.com/idleberg/SublimeLinter-contrib-makensis",
+            "labels": ["linting", "SublimeLinter", "nsis", "makensis"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        }
+        {
             "name": "SublimeLinter-contrib-mdl",
             "details": "https://github.com/roadhump/SublimeLinter-contrib-mdl",
             "labels": ["linting", "SublimeLinter", "mdl", "markdown"],


### PR DESCRIPTION
The build currently fails with the following error message, even though there _is_ a blank line before the class docstring:

````
./linter.py:20 in public class `Makensis`:
        D211: No blank lines allowed before class docstring (found 1)
```

If I remove it, I get this instead:

```
./linter.py:20 in public class `Makensis`:
D203: 1 blank line required before class docstring (found 0)
```