### PR TITLE
Restrict contrib-swiftlint to OSX platform

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -888,6 +888,7 @@
             "releases": [
                 {
                     "sublime_text": ">=3000",
+                    "platforms": ["osx"],
                     "tags": true
                 }
             ]


### PR DESCRIPTION
swiftlint is only available for OSX.