### PR TITLE
Change maintainer for SublimeLinter-contrib-elm-make

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -213,7 +213,7 @@
         },
         {
             "name": "SublimeLinter-contrib-elm-make",
-            "details": "https://github.com/bbugh/SublimeLinter-contrib-elm-make",
+            "details": "https://github.com/sentience/SublimeLinter-contrib-elm-make",
             "labels": ["linting", "SublimeLinter", "elm"],
             "releases": [
                 {


### PR DESCRIPTION
Per https://github.com/bbugh/SublimeLinter-contrib-elm-make/issues/5, I will be taking ownership of this package. This update alters the channel to point to my updated version of this repository, which has a new release tagged and ready to go for users of this package.

I expect the previous owner, @bbugh will chime in here to confirm that he is happy for this change to go ahead.