### PR TITLE
Update stylint repo owner

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1037,7 +1037,7 @@
         },
         {
             "name": "SublimeLinter-contrib-stylint",
-            "details": "https://github.com/jackbrewer/SublimeLinter-contrib-stylint",
+            "details": "https://github.com/markalfred/SublimeLinter-contrib-stylint",
             "labels": ["linting", "SublimeLinter", "stylint", "stylus"],
             "releases": [
                 {


### PR DESCRIPTION
Per markalfred/SublimeLinter-contrib-stylint#6

The previous URL should work for a long time, but this should be updated at some point.