### PR TITLE
Add contrib 'markdownlint' linter

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -675,6 +675,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-markdownlint",
+            "details": "https://github.com/jonlabelle/SublimeLinter-contrib-markdownlint",
+            "labels": ["linting", "SublimeLinter", "markdown", "markdownlint"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-mdl",
             "details": "https://github.com/roadhump/SublimeLinter-contrib-mdl",
             "labels": ["linting", "SublimeLinter", "mdl", "markdown"],


### PR DESCRIPTION
- **Description:** Sublime Text linter for Markdown/CommonMark files. This linter wraps the node.js NPM package [Markdownlint](https://github.com/DavidAnson/markdownlint).
- **Repository:** <https://github.com/jonlabelle/SublimeLinter-contrib-markdownlint>
- **Tag:** <https://github.com/jonlabelle/SublimeLinter-contrib-markdownlint/tree/1.0.0>