### PR TITLE
Move gotype to org

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -454,17 +454,6 @@
             ]
         },
         {
-            "name": "SublimeLinter-contrib-gotype",
-            "details": "https://github.com/SirReal/SublimeLinter-contrib-gotype",
-            "labels": ["linting", "SublimeLinter", "go"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true
-                }
-            ]
-        },
-        {
             "name": "SublimeLinter-contrib-govet",
             "details": "https://github.com/SirReal/SublimeLinter-contrib-govet",
             "labels": ["linting", "SublimeLinter", "go"],

--- a/org.json
+++ b/org.json
@@ -412,6 +412,18 @@
                     "tags": true
                 }
             ]
+        },
+        {
+            "name": "SublimeLinter-gotype",
+            "details": "https://github.com/SublimeLinter/SublimeLinter-gotype",
+            "previous_names": ["SublimeLinter-contrib-gotype"],
+            "labels": ["linting", "SublimeLinter", "go"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Moving formerly contrib package to repo: https://github.com/SublimeLinter/SublimeLinter-gotype