### PR TITLE
Add PHPStan linter

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -756,6 +756,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-phpstan",
+            "details": "https://github.com/Rockstar04/SublimeLinter-contrib-phpstan",
+            "labels": ["linting", "SublimeLinter", "phpstan"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-polylint",
             "details": "https://github.com/nomego/SublimeLinter-contrib-polylint",
             "labels": ["linting", "SublimeLinter", "html", "polymer"],
@@ -1220,17 +1231,6 @@
             "name": "SublimeLinter-contrib-xqlint",
             "details": "https://github.com/jmeischner/SublimeLinter-contrib-xqlint",
             "labels": ["linting", "SublimeLinter", "xquery"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true
-                }
-            ]
-        },
-        {
-            "name": "SublimeLinter-contrib-phpstan",
-            "details": "https://github.com/Rockstar04/SublimeLinter-contrib-phpstan",
-            "labels": ["linting", "SublimeLinter", "phpstan"],
             "releases": [
                 {
                     "sublime_text": ">=3000",

--- a/contrib.json
+++ b/contrib.json
@@ -1226,6 +1226,17 @@
                     "tags": true
                 }
             ]
+        },
+        {
+            "name": "SublimeLinter-contrib-phpstan",
+            "details": "https://github.com/Rockstar04/SublimeLinter-contrib-phpstan",
+            "labels": ["linting", "SublimeLinter", "phpstan"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
PHPStan is a static analysis tool for PHP 7.1+.

> PHPStan moves PHP closer to compiled languages in the sense that the correctness of each line of the code can be checked before you run the actual line.
> PHPStan works best with modern object-oriented code. The more strongly-typed your code is, the more information you give PHPStan to work with.