### PR TITLE
Add Verilog/vlog support in SublimeLinter-contrib-vcom

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1197,7 +1197,7 @@
         {
             "name": "SublimeLinter-contrib-vcom",
             "details": "https://github.com/jevogel/SublimeLinter-contrib-vcom",
-            "labels": ["linting", "SublimeLinter", "vhdl", "vcom", "modelsim"],
+            "labels": ["linting", "SublimeLinter", "vhdl", "vcom", "verilog", "vlog", "systemverilog", "modelsim", "questasim"],
             "releases": [
                 {
                     "sublime_text": ">=3000",


### PR DESCRIPTION
Updated SublimeLinter-contrib-vcom to support vlog (Verilog compiler included with ModelSim).
Added tags indicating this fact.