### PR TITLE
Change SublimeLinter-contrib-vcom to SublimeLinter-contrib-modelsim

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -733,6 +733,18 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-modelsim",
+            "details": "https://github.com/jevogel/SublimeLinter-contrib-modelsim",
+            "labels": ["linting", "SublimeLinter", "vhdl", "verilog", "systemverilog", "vcom", "vlog", "modelsim", "questasim"],
+            "previous_names": ["SublimeLinter-contrib-vcom"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-mypy",
             "details": "https://github.com/fredcallaway/SublimeLinter-contrib-mypy",
             "labels": ["linting", "SublimeLinter", "python"],
@@ -1187,17 +1199,6 @@
             "name": "SublimeLinter-contrib-vale",
             "details": "https://github.com/admhlt/SublimeLinter-contrib-vale",
             "labels": ["linting", "SublimeLinter", "markdown", "plain text", "prose"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true
-                }
-            ]
-        },
-        {
-            "name": "SublimeLinter-contrib-vcom",
-            "details": "https://github.com/jevogel/SublimeLinter-contrib-vcom",
-            "labels": ["linting", "SublimeLinter", "vhdl", "vcom", "verilog", "vlog", "systemverilog", "modelsim", "questasim"],
             "releases": [
                 {
                     "sublime_text": ">=3000",


### PR DESCRIPTION
Change the name of the plugin to more accurately describe the functionality. Change name, realphabetize the file, change repo address, and add `previous_names` key.