### PR TITLE
Added SublimeLinter-contrib-eslint_d-with-lightscript-support

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -366,6 +366,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-eslint_d-with-lightscript-support",
+            "details": "https://github.com/Darkle/SublimeLinter-contrib-eslint_d-with-lightscript-support",
+            "labels": ["linting", "SublimeLinter", "eslint_d"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-erlc",
             "details": "https://github.com/teh-cmc/SublimeLinter-contrib-erlc",
             "labels": ["linting", "SublimeLinter", "erlc", "erlang"],


### PR DESCRIPTION
This is basically the same as https://github.com/roadhump/SublimeLinter-contrib-eslint_d but with support added for the LightScript language. I would have liked to have added this to the original package, but it seems it's no longer maintained or accepting Pull Requests.