### PR TITLE
Add golangci-lint plugin

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -509,8 +509,8 @@
             ]
         },
         {
-            "name": "SublimeLinter-contrib-golangcilint",
-            "details": "https://github.com/alecthomas/SublimeLinter-contrib-golang-cilint",
+            "name": "SublimeLinter-golangcilint",
+            "details": "https://github.com/cixtor/SublimeLinter-golangcilint",
             "labels": ["linting", "SublimeLinter", "go", "golang"],
             "releases": [
                 {

--- a/contrib.json
+++ b/contrib.json
@@ -509,6 +509,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-golangcilint",
+            "details": "https://github.com/cixtor/SublimeLinter-golangcilint",
+            "labels": ["linting", "SublimeLinter", "go", "golang"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-gosimple",
             "details": "https://github.com/clocklear/SublimeLinter-contrib-gosimple",
             "labels": ["linting", "SublimeLinter", "go"],

--- a/contrib.json
+++ b/contrib.json
@@ -509,17 +509,6 @@
             ]
         },
         {
-            "name": "SublimeLinter-golangcilint",
-            "details": "https://github.com/cixtor/SublimeLinter-golangcilint",
-            "labels": ["linting", "SublimeLinter", "go", "golang"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true
-                }
-            ]
-        },
-        {
             "name": "SublimeLinter-contrib-gosimple",
             "details": "https://github.com/clocklear/SublimeLinter-contrib-gosimple",
             "labels": ["linting", "SublimeLinter", "go"],

--- a/contrib.json
+++ b/contrib.json
@@ -509,8 +509,8 @@
             ]
         },
         {
-            "name": "SublimeLinter-golangcilint",
-            "details": "https://github.com/cixtor/SublimeLinter-golangcilint",
+            "name": "SublimeLinter-contrib-golangcilint",
+            "details": "https://github.com/alecthomas/SublimeLinter-contrib-golang-cilint",
             "labels": ["linting", "SublimeLinter", "go", "golang"],
             "releases": [
                 {

--- a/org.json
+++ b/org.json
@@ -518,6 +518,17 @@
                     "tags": true
                 }
             ]
+        },
+        {
+            "name": "SublimeLinter-golangcilint",
+            "details": "https://github.com/SublimeLinter/SublimeLinter-golangcilint",
+            "labels": ["linting", "SublimeLinter", "go", "golang"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Project inspired by alecthomas version [1] which unfortunately doesn’t works very well with the latest version of golangci-lint nor SublimeText and hasn’t been updated during the last 9+ months. He also announced a few days ago that he’s going to deprecate “gometalinter” [2] another popular linter in the Go (golang) community, so I jumped right away to offer an alternative.

**Note:** I want to transfer this linter to the SublimeLinter organization.

[1] https://github.com/alecthomas/SublimeLinter-contrib-golang-cilint
[2] https://github.com/alecthomas/gometalinter/issues/590