### PR TITLE
Linter for Windows Powershell

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -934,6 +934,18 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-Powershell",
+            "details": "https://github.com/EdrisT/SublimeLinter-contrib-Powershell",
+            "previous_names": ["SublimeLinter-contrib-Powershell"],
+            "labels": ["linting", "SublimeLinter", "Powershell", "PS"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-proselint",
             "details": "https://github.com/amperser/SublimeLinter-contrib-proselint",
             "labels": ["linting", "SublimeLinter", "markdown", "text", "writing"],
@@ -1424,19 +1436,6 @@
                 {
                     "sublime_text": ">=3000",
                     "tags": true
-                }
-            ]
-        },
-        {
-            "name": "SublimeLinter-contrib-Powershell",
-            "details": "https://github.com/EdrisT/SublimeLinter-contrib-Powershell",
-            "previous_names": ["SublimeLinter-contrib-Powershell"],
-            "labels": ["linting", "SublimeLinter", "Powershell", "PS"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true,
-                    "platforms": ["windows"]
                 }
             ]
         }

--- a/contrib.json
+++ b/contrib.json
@@ -1426,6 +1426,19 @@
                     "tags": true
                 }
             ]
+        },
+        {
+            "name": "SublimeLinter-contrib-Powershell",
+            "details": "https://github.com/EdrisT/SublimeLinter-contrib-Powershell",
+            "previous_names": ["SublimeLinter-contrib-Powershell"],
+            "labels": ["linting", "SublimeLinter", "Powershell", "PS"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true,
+                    "platforms": ["windows"]
+                }
+            ]
         }
     ]
 }

--- a/contrib.json
+++ b/contrib.json
@@ -936,7 +936,6 @@
         {
             "name": "SublimeLinter-contrib-Powershell",
             "details": "https://github.com/EdrisT/SublimeLinter-contrib-Powershell",
-            "previous_names": ["SublimeLinter-contrib-Powershell"],
             "labels": ["linting", "SublimeLinter", "Powershell", "PS"],
             "releases": [
                 {

--- a/org.json
+++ b/org.json
@@ -529,19 +529,6 @@
                     "tags": true
                 }
             ]
-        },
-        {
-            "name": "SublimeLinter-contrib-Powershell",
-            "details": "https://github.com/EdrisT/SublimeLinter-contrib-Powershell",
-            "previous_names": ["SublimeLinter-contrib-Powershell"],
-            "labels": ["linting", "SublimeLinter", "Powershell", "PS"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true,
-                    "platforms": ["windows"]
-                }
-            ]
         }
     ]
 }

--- a/org.json
+++ b/org.json
@@ -529,6 +529,19 @@
                     "tags": true
                 }
             ]
+        },
+        {
+            "name": "SublimeLinter-contrib-Powershell",
+            "details": "https://github.com/EdrisT/SublimeLinter-contrib-Powershell",
+            "previous_names": ["SublimeLinter-contrib-Powershell"],
+            "labels": ["linting", "SublimeLinter", "Powershell", "PS"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true,
+                    "platforms": ["windows"]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
A simple linter for Windows Powershell making use of PSScriptAnalyzer.
This plugin works on Windows PowerShell 3.0 or greater and PowerShell Core 6.1.0 or greater on Windows/Linux/macOS.