### PR TITLE
Added SublimeLinter-contrib-qmllint

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1001,6 +1001,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-qmllint",
+            "details": "https://github.com/temideoye/SublimeLinter-contrib-qmllint",
+            "labels": ["linting", "SublimeLinter", "Qt", "QML"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-raml-cop",
             "details": "https://github.com/thebinarypenguin/SublimeLinter-contrib-raml-cop",
             "labels": ["linting", "SublimeLinter", "raml"],


### PR DESCRIPTION
This plugin provides an interface to Qt's [qmllint](https://code.qt.io/cgit/qt/qtdeclarative.git/tree/tools/qmllint).

*Sample code*
![Screen Shot 2019-05-27 at 2 38 17 PM](https://user-images.githubusercontent.com/8375739/58436892-29b54380-808d-11e9-9521-582846ed67f9.png)

*Lint view*
![Screen Shot 2019-05-27 at 2 40 40 PM](https://user-images.githubusercontent.com/8375739/58436942-6c771b80-808d-11e9-91d0-cb6936e639b5.png)