### PR TITLE
Add SublimeLinter-contrib-tlint

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1294,6 +1294,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-tlint",
+            "details": "https://github.com/tightenco/tlint-sublime-plugin",
+            "labels": ["linting", "SublimeLinter", "tlint"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-twiglint",
             "details": "https://github.com/maxgalbu/SublimeLinter-contrib-twiglint",
             "labels": ["linting", "SublimeLinter", "twig"],


### PR DESCRIPTION
This PR adds the [SublimeLinter-tlint](https://github.com/tightenco/tlint-sublime-plugin) plugin to the package control channel.  This plugin adds `SublimeLinter` support for [tlint](https://github.com/tightenco/tlint), which is a Tighten linter for Laravel conventions.

**Sample Code**
![image](https://user-images.githubusercontent.com/1121383/59945095-257e0b00-942c-11e9-94ee-708c086fa734.png)

**With Lint Error**
![image](https://user-images.githubusercontent.com/1121383/59945131-3e86bc00-942c-11e9-9776-18fdc3024422.png)