### PR TITLE
Add contrib plugin SublimeLinter-contrib-standardrb (Ruby) linter.

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1193,6 +1193,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-standardrb",
+            "details": "https://github.com/testdouble/SublimeLinter-contrib-standardrb",
+            "labels": ["linting", "SublimeLinter", "standard", "standardrb", "ruby"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-stylelint_d",
             "details": "https://github.com/jo-sm/SublimeLinter-contrib-stylelint_d",
             "labels": ["linting", "SublimeLinter", "css", "less", "sass"],


### PR DESCRIPTION
This PR adds a contrib plugin to lint Ruby using StandardRB as the linter. The plugin includes a `prefer_standard` option to check for the presence of config files and selectively enable/disable StandardRB or Rubocop as appropriate.

See:
https://github.com/testdouble/SublimeLinter-contrib-standardrb
https://github.com/testdouble/standard

**Quick Note:** As this is my first pass at a Sublime plugin I'd greatly appreciate any feedback on anything that can/should be improved prior to merging this PR. I'd also be very interested in information to direct me to how automated testing that can be implemented for linter plugins. 🙂