### PR TITLE
Add archives documentation linting plugin

### DIFF
--- a/org.json
+++ b/org.json
@@ -31,6 +31,16 @@
             ]
         },
         {
+            "details": "https://github.com/jpetrucciani/SublimeLinter-archives",
+            "labels": ["linting", "SublimeLinter", "archives", "documentation"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "details": "https://github.com/SublimeLinter/SublimeLinter-bandit",
             "labels": ["linting", "SublimeLinter", "python", "security"],
             "releases": [


### PR DESCRIPTION
archives (https://github.com/jpetrucciani/archives) is a new documentation linter and doc-gen program that I'm currently working on!

This currently is pretty barebones at the moment, and based off of the SublimeLinter-flake8 plugin (as the base output format of archives is flake8 styled)