### PR TITLE
move raml-cop into the org

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1000,17 +1000,6 @@
             ]
         },
         {
-            "name": "SublimeLinter-contrib-raml-cop",
-            "details": "https://github.com/thebinarypenguin/SublimeLinter-contrib-raml-cop",
-            "labels": ["linting", "SublimeLinter", "raml"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true
-                }
-            ]
-        },
-        {
             "name": "SublimeLinter-contrib-reek",
             "details": "https://github.com/codequest-eu/SublimeLinter-contrib-reek",
             "labels": ["linting", "SublimeLinter", "ruby"],

--- a/org.json
+++ b/org.json
@@ -481,6 +481,18 @@
             ]
         },
         {
+            "name": "SublimeLinter-raml-cop",
+            "details": "https://github.com/SublimeLinter/SublimeLinter-raml-cop",
+            "labels": ["linting", "SublimeLinter", "raml"],
+            "previous_names": ["SublimeLinter-contrib-raml-cop"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "details": "https://github.com/SublimeLinter/SublimeLinter-rst",
             "labels": ["linting", "SublimeLinter", "restructuredtext", "rst"],
             "releases": [


### PR DESCRIPTION
It's a pretty simple plugin, apparently abandoned by the creator. So we move it into the org to keep it alive. @kaste I overlook something every time I do this, so perhaps you can have a look if it's ok?

https://github.com/SublimeLinter/SublimeLinter-raml-cop