### PR TITLE
Update SublimeLinter-contrib-iverilog information

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -621,7 +621,8 @@
         },
         {
             "name": "SublimeLinter-contrib-iverilog",
-            "details": "https://github.com/jfcherng/SublimeLinter-contrib-iverilog",
+            "details": "https://github.com/jfcherng-sublime/SublimeLinter-contrib-iverilog",
+            "author": ["jfcherng"],
             "labels": ["linting", "SublimeLinter", "verilog"],
             "releases": [
                 {


### PR DESCRIPTION
I moved all my ST-related repositories to `jfcherng-sublime` organization and the author now is shown as `jfcherng-sublime` rather than `jfcherng` on Package Control. This PR fixes that.