### PR TITLE
Updated codeclimate

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -257,11 +257,12 @@
         },
         {
             "name": "SublimeLinter-contrib-codeclimate",
-            "details": "https://github.com/codeclimate/SublimeLinter-contrib-codeclimate",
+            "details": "https://github.com/meengit/SublimeLinter-contrib-codeclimate",
             "labels": ["linting", "SublimeLinter", "codeclimate"],
             "releases": [
                 {
                     "sublime_text": ">=3000",
+                    "platforms": ["osx", "linux"],
                     "tags": true
                 }
             ]

--- a/contrib.json
+++ b/contrib.json
@@ -262,7 +262,6 @@
             "releases": [
                 {
                     "sublime_text": ">=3000",
-                    "platforms": ["osx", "linux"],
                     "tags": true
                 }
             ]


### PR DESCRIPTION
Hi!

I tried to upgrade the codeclimate plugin in https://github.com/codeclimate/SublimeLinter-contrib-codeclimate/pull/3. Since there is no response by the original developers, I will overtake the responsibility for this plugin now.

~Further, I decided to restrict the platforms to `osx`, and `linux` since the plugin's implementation is optimized with the application on these two platforms. I see some possibilities also to include support for `windows` in some further releases. However, this highly depends on what codeclimate will do with it's CLI and needs some serious testing and maybe some workarounds before.~

I just realized that most installations at Package Control are from Windows Users. The statistics say WIN 2K, Mac 539, Linux 205 users. I didn't test against Windows, but because "Package Control" shows this clear picture, I suggest removing the platform restriction for my replacement because it is closely following the original implementation.