### PR TITLE
Add SublimeLinter-contrib-PSScriptAnalyzer (PowerShell)

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -990,6 +990,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-PSScriptAnalyzer",
+            "details": "https://github.com/spajak/SublimeLinter-contrib-PSScriptAnalyzer",
+            "labels": ["linting", "SublimeLinter", "PowerShell", "PSScriptAnalyzer", "pwsh"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },	    
+        {
             "name": "SublimeLinter-contrib-puppet",
             "details": "https://github.com/dschaaff/SublimeLinter-puppet",
             "labels": ["linting", "SublimeLinter", "puppet"],


### PR DESCRIPTION
This linter is using pipe, so no need for tmp file. It base64 encodes sub command argument to pwsh.exe, so it's safer.
(SublimeLinter-contrib-Powershell didn't work for me)