### PR TITLE
Added SublimeLinter-contrib-csl for Citation Style Language

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -289,9 +289,9 @@
             ]
         },
         {
-            "name": "SublimeLinter-contrib-csstree",
-            "details": "https://github.com/csstree/SublimeLinter-contrib-csstree",
-            "labels": ["linting", "SublimeLinter", "css"],
+            "name": "SublimeLinter-contrib-csl",
+            "details": "https://github.com/Marcool04/SublimeLinter-contrib-csl",
+            "labels": ["linting", "SublimeLinter", "csl", "Citation style language"],
             "releases": [
                 {
                     "sublime_text": ">=3000",
@@ -300,9 +300,9 @@
             ]
         },
         {
-            "name": "SublimeLinter-contrib-csl",
-            "details": "https://github.com/Marcool04/SublimeLinter-contrib-csl",
-            "labels": ["linting", "SublimeLinter", "csl", "Citation style language"],
+            "name": "SublimeLinter-contrib-csstree",
+            "details": "https://github.com/csstree/SublimeLinter-contrib-csstree",
+            "labels": ["linting", "SublimeLinter", "css"],
             "releases": [
                 {
                     "sublime_text": ">=3000",

--- a/contrib.json
+++ b/contrib.json
@@ -301,7 +301,7 @@
         },
         {
             "name": "SublimeLinter-contrib-csl",
-            "details": "https://github.com/Marcool04/SublimeLinter-csl",
+            "details": "https://github.com/Marcool04/SublimeLinter-contrib-csl",
             "labels": ["linting", "SublimeLinter", "csl", "Citation style language"],
             "releases": [
                 {

--- a/contrib.json
+++ b/contrib.json
@@ -300,6 +300,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-csl",
+            "details": "https://github.com/Marcool04/SublimeLinter-csl",
+            "labels": ["linting", "SublimeLinter", "csl", "Citation style language"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-dennis",
             "details": "https://github.com/NotSqrt/SublimeLinter-contrib-dennis",
             "labels": ["linting", "SublimeLinter", "Gettext"],


### PR DESCRIPTION
Hi,
I just thought I'd share this linter I created to integrate a shell script that validates Citation Style Language (CSL), a specific schema of XML.
Thanks in advance for your reviews, advice and possible inclusion.
PS: I'm sorry about the name, I didn't realize all contribs should include SublimeLinter-contrib-name, and named my repo SublimeLinter-csl 😕 Is that a problem?