### PR TITLE
Add vala-lint SublimeLinter plugin repo to contrib.json

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1461,6 +1461,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-vala-lint",
+            "details": "https://github.com/colinkiama/SublimeLinter-contrib-vala-lint",
+            "labels": ["linting", "SublimeLinter", "vala", "gnome"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-verilator",
             "details": "https://github.com/poucotm/SublimeLinter-contrib-verilator",
             "labels": ["linting", "SublimeLinter", "verilog", "systemverilog", "verilator"],


### PR DESCRIPTION
Adds [Vala-Lint](https://github.com/vala-lang/vala-lint) support to SublimeLinter

![Screenshot from 2021-11-03 02-44-26](https://user-images.githubusercontent.com/16501024/140003335-85f0f898-37e7-431a-a603-0c0a382954d0.png)
