### PR TITLE
Add jsonschema-lint

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -676,6 +676,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-jsonschema-lint",
+            "details": "https://github.com/jacksmith15/SublimeLinter-contrib-jsonschema-lint",
+            "labels": ["linting", "SublimeLinter", "jsonschema", "json", "yaml"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-julialint",
             "details": "https://github.com/tomaskrehlik/SublimeLinter-contrib-julialint",
             "labels": ["linting", "SublimeLinter", "julia"],


### PR DESCRIPTION
This PR adds [jsonschema-lint](https://github.com/jacksmith15/jsonschema-lint) to `contrib.json`.

![Screenshot from 2021-11-14 16-13-54](https://user-images.githubusercontent.com/22217353/141689105-6e1cda1f-7f5b-4d6c-bbc1-8814846fbd4d.png)
