### PR TITLE
Add SublimeLinter-luau

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -855,6 +855,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-luau",
+            "details": "https://github.com/zeux/SublimeLinter-luau",
+            "labels": ["linting","SublimeLinter","lua","roblox"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-makensis",
             "details": "https://github.com/idleberg/SublimeLinter-contrib-makensis",
             "labels": ["linting", "SublimeLinter", "nsis", "makensis"],


### PR DESCRIPTION
This change adds a lint plugin for luau-analyze that's part of Luau (https://luau-lang.org).

![image](https://user-images.githubusercontent.com/1106629/145653816-235bc77f-7a3d-4c41-9115-ec53e70e0dc9.png)
