### PR TITLE
Add SublimeLinter-contrib-zig-check

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1627,6 +1627,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-zig-check",
+            "details": "https://github.com/alexkuz/SublimeLinter-contrib-zig-check",
+            "labels": ["linting", "SublimeLinter", "zig"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-ziglint",
             "details": "https://github.com/squeek502/SublimeLinter-contrib-ziglint",
             "labels": ["linting", "SublimeLinter", "zig"],


### PR DESCRIPTION
Plugin lints `*.zig` files using `zig ast-check` command.