### PR TITLE
Fix: `xo` repo moved to the `xojs` org

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1573,7 +1573,7 @@
         },
         {
             "name": "SublimeLinter-contrib-xo",
-            "details": "https://github.com/sindresorhus/SublimeLinter-contrib-xo",
+            "details": "https://github.com/xojs/SublimeLinter-contrib-xo",
             "labels": ["linting", "SublimeLinter", "javascript", "xo"],
             "releases": [
                 {


### PR DESCRIPTION
Fix the link to `xo` as it moved into the `xojs` org: https://github.com/xojs/SublimeLinter-contrib-xo