### PR TITLE
Add plugin for Revive linter

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1144,6 +1144,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-revive",
+            "details": "https://github.com/jsmith0684/SublimeLinter-contrib-revive",
+            "labels": ["linting", "SublimeLinter", "go", "golang"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-roslint",
             "details": "https://github.com/sotilrac/SublimeLinter-roslint",
             "labels": ["linting", "SublimeLinter", "ROS", "roslint", "c++"],
@@ -1653,17 +1664,6 @@
             "name": "SublimeLinter-contrib-ziglint",
             "details": "https://github.com/squeek502/SublimeLinter-contrib-ziglint",
             "labels": ["linting", "SublimeLinter", "zig"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true
-                }
-            ]
-        },
-        {
-            "name": "SublimeLinter-contrib-revive",
-            "details": "https://github.com/jsmith0684/SublimeLinter-contrib-revive",
-            "labels": ["linting", "SublimeLinter", "go", "golang"],
             "releases": [
                 {
                     "sublime_text": ">=3000",

--- a/contrib.json
+++ b/contrib.json
@@ -1659,6 +1659,17 @@
                     "tags": true
                 }
             ]
+        },
+        {
+            "name": "SublimeLinter-contrib-revive",
+            "details": "https://github.com/jsmith0684/SublimeLinter-contrib-revive",
+            "labels": ["linting", "SublimeLinter", "go", "golang"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Add plugin for the Revive linter for the Go programming language.

Repository: [https://github.com/jsmith0684/SublimeLinter-contrib-revive](https://github.com/jsmith0684/SublimeLinter-contrib-revive)
Docs: [https://revive.run](https://revive.run)
Source: [https://github.com/mgechev/revive](https://github.com/mgechev/revive)