### PR TITLE
Makefile linter

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1681,6 +1681,17 @@
                     "tags": true
                 }
             ]
+        },
+        {
+            "name": "SublimeLinter-makefile",
+            "details": "https://github.com/giampaolo/SublimeLinter-makefile",
+            "labels": ["linting", "makefile", "make"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
         }
     ]
 }

--- a/contrib.json
+++ b/contrib.json
@@ -888,6 +888,17 @@
             ]
         },
         {
+            "name": "SublimeLinter-contrib-makefile",
+            "details": "https://github.com/giampaolo/SublimeLinter-contrib-makefile",
+            "labels": ["linting", "makefile", "make"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "SublimeLinter-contrib-makensis",
             "details": "https://github.com/idleberg/SublimeLinter-contrib-makensis",
             "labels": ["linting", "SublimeLinter", "nsis", "makensis"],
@@ -1675,17 +1686,6 @@
             "name": "SublimeLinter-contrib-ziglint",
             "details": "https://github.com/squeek502/SublimeLinter-contrib-ziglint",
             "labels": ["linting", "SublimeLinter", "zig"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true
-                }
-            ]
-        },
-        {
-            "name": "SublimeLinter-contrib-makefile",
-            "details": "https://github.com/giampaolo/SublimeLinter-contrib-makefile",
-            "labels": ["linting", "makefile", "make"],
             "releases": [
                 {
                     "sublime_text": ">=3000",

--- a/contrib.json
+++ b/contrib.json
@@ -1076,7 +1076,7 @@
                     "tags": true
                 }
             ]
-        },	    
+        },
         {
             "name": "SublimeLinter-contrib-puppet",
             "details": "https://github.com/dschaaff/SublimeLinter-puppet",
@@ -1683,8 +1683,8 @@
             ]
         },
         {
-            "name": "SublimeLinter-makefile",
-            "details": "https://github.com/giampaolo/SublimeLinter-makefile",
+            "name": "SublimeLinter-contrib-makefile",
+            "details": "https://github.com/giampaolo/SublimeLinter-contrib-makefile",
             "labels": ["linting", "makefile", "make"],
             "releases": [
                 {


### PR DESCRIPTION
I recently worked on this: https://github.com/giampaolo/SublimeLinter-contrib-makefile. The motivation which led me to it is because the only Makefile linter I found is https://github.com/mrtazz/checkmake, which provides a limited set of rules:

```
$ go run github.com/mrtazz/checkmake/cmd/checkmake@latest --list-rules
                                                      
        NAME                   DESCRIPTION            
                                                      
  maxbodylength       Target bodies should be kept    
                      simple and short.               
  minphony            Minimum required phony targets  
                      must be present                 
  phonydeclared       Every target without a body     
                      needs to be marked PHONY        
  timestampexpanded   timestamp variables should be   
                      simply expanded   
```

I use Makefiles in all of my projects, not to compile stuff, but to run repetitive tasks. I wanted to be able to identify (amongst other things) undefined variable names, undefined target names, and use of spaces instead of tabs. As such I decided to write my own plugin and came up with this.

In the future I may decide to turn this into a generic CLI tool, but for now this is implemented as a plugin which can only be used with Sublime Text + SublimeLinter.
