### PR TITLE
Freeze SublimeLinter version for ST3

### DIFF
--- a/org.json
+++ b/org.json
@@ -14,7 +14,11 @@
                     "tags": true
                 },
                 {
-                    "sublime_text": ">=3000",
+                    "sublime_text": "3000 - 3999",
+                    "tags": "st3-"
+                },
+                {
+                    "sublime_text": ">=4000",
                     "tags": true
                 }
             ]


### PR DESCRIPTION
This is in preparation for a move to the py38 plugin host.