### PR TITLE
Freeze SublimeLinter-gcc version for ST3

### DIFF
--- a/org.json
+++ b/org.json
@@ -165,7 +165,11 @@
             "previous_names": ["SublimeLinter-contrib-gcc"],
             "releases": [
                 {
-                    "sublime_text": ">=3000",
+                    "sublime_text": "3000 - 3999",
+                    "tags": "st3-"
+                },
+                {
+                    "sublime_text": ">=4000",
                     "tags": true
                 }
             ]


### PR DESCRIPTION
ST 3 tag has been created in https://github.com/SublimeLinter/SublimeLinter-gcc/tags

I can't create a new tag for ST4/py38 until this PR gets merged.