### PR TITLE
Freeze SublimeLinter-contrib-iverilog version for ST3

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -703,7 +703,11 @@
             "labels": ["linting", "SublimeLinter", "verilog"],
             "releases": [
                 {
-                    "sublime_text": ">=3000",
+                    "sublime_text": "3000 - 3999",
+                    "tags": "st3-"
+                },
+                {
+                    "sublime_text": ">=4000",
                     "tags": true
                 }
             ]


### PR DESCRIPTION
ST 3 tag has been created in https://github.com/jfcherng-Sublime/SublimeLinter-contrib-iverilog/tags

I can't create a new tag for ST4/py38 until this PR gets merged.