### PR TITLE
move php-cs-fixer into the org

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -1038,17 +1038,6 @@
                 }
             ]
         },
-        {
-            "name": "SublimeLinter-contrib-php-cs-fixer",
-            "details": "https://github.com/jhoff/SublimeLinter-contrib-php-cs-fixer",
-            "labels": ["linting", "SublimeLinter", "php-cs-fixer"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true
-                }
-            ]
-        },
 	    {
             "name": "SublimeLinter-contrib-phpins",
             "details": "https://github.com/ta-tikoma/SublimeLinter-phpins",

--- a/org.json
+++ b/org.json
@@ -547,6 +547,21 @@
             ]
         },
         {
+            "details": "https://github.com/SublimeLinter/SublimeLinter-php-cs-fixer",
+            "previous_names": ["SublimeLinter-contrib-php-cs-fixer"],
+            "labels": ["linting", "SublimeLinter", "php", "php-cs-fixer"],
+            "releases": [
+                {
+                    "sublime_text": "3000 - 3999",
+                    "tags": "st3-"
+                },
+                {
+                    "sublime_text": ">=4000",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "details": "https://github.com/SublimeLinter/SublimeLinter-phpcs",
             "labels": ["linting", "SublimeLinter", "phpcs", "php"],
             "releases": [


### PR DESCRIPTION
The original repo has been [dead](https://github.com/jhoff/SublimeLinter-contrib-php-cs-fixer/pull/15#issuecomment-1479403666) for quite a while. I forked it into the org, and pulled in all the work @gerardroche has done.