### PR TITLE
Remove "SublimeLinter-contrib-fecs"

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -511,17 +511,6 @@
             ]
         },
         {
-            "name": "SublimeLinter-contrib-fecs",
-            "details": "https://github.com/robbenmu/SublimeLinter-contrib-fecs",
-            "labels": ["linting", "SublimeLinter", "javascript"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true
-                }
-            ]
-        },
-        {
             "name": "SublimeLinter-contrib-flog",
             "details": "https://github.com/icnagy/SublimeLinter-contrib-flog",
             "labels": ["linting", "SublimeLinter", "flog"],


### PR DESCRIPTION
"fecs" has actually to public tags so it can't be listed and installed using Package Control.