### PR TITLE
this is actually not a channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 package_control_channel
 =======================
 
-Private channel for SublimeLinter plugins.
+Private repository for SublimeLinter plugins.
 
-To add your linter to package control, please open a pull request.
+To add your linter to Package Control, please open a pull request.


### PR DESCRIPTION
So, I'm reviewing documentation for the site etc. If we're strict about the verbiage, this is a repository not a channel and it is joined together with other repositories into the final public channel.

https://github.com/wbond/packagecontrol.io/blob/master/app/html/docs/channels_and_repositories.html#L7

... assuming I understand this correctly of course. Note that sublimelsp calls their version of same "repository": https://github.com/sublimelsp/repository